### PR TITLE
Get Grafana data GKE-ready

### DIFF
--- a/resources/grafana/dashboard-cluster-alarms.yaml
+++ b/resources/grafana/dashboard-cluster-alarms.yaml
@@ -3,1523 +3,1277 @@ kind: ConfigMap
 metadata:
   name: grafana-cluster-alarms-dashboard
   labels:
-     grafana_dashboard: "true"
+    grafana_dashboard: "true"
 data:
   kubernetes-cluster-alarms.json: |-
-      {
-          "annotations": {
-            "list": [
-              {
-                "builtIn": 1,
-                "datasource": "-- Grafana --",
-                "enable": true,
-                "hide": true,
-                "iconColor": "rgba(0, 211, 255, 1)",
-                "name": "Annotations & Alerts",
-                "type": "dashboard"
-              }
-            ]
-          },
-          "description": "Monitors Kubernetes cluster using Prometheus. Shows overall cluster CPU / Memory / Filesystem usage as well as individual pod, containers, systemd services statistics. Uses cAdvisor metrics only.",
-          "editable": false,
-          "gnetId": 315,
-          "graphTooltip": 0,
-          "hideControls": false,
-          "links": [],
-          "refresh": false,
-          "rows": [
-            {
-              "collapse": false,
-              "height": "250px",
-              "panels": [
-                {
-                  "alert": {
-                    "conditions": [
-                      {
-                        "evaluator": {
-                          "params": [
-                            50
-                          ],
-                          "type": "gt"
-                        },
-                        "operator": {
-                          "type": "and"
-                        },
-                        "query": {
-                          "params": [
-                            "A",
-                            "5m",
-                            "now"
-                          ]
-                        },
-                        "reducer": {
-                          "params": [],
-                          "type": "max"
-                        },
-                        "type": "query"
-                      }
-                    ],
-                    "executionErrorState": "alerting",
-                    "frequency": "60s",
-                    "handler": 1,
-                    "name": "Master Node Memory Usage alert",
-                    "noDataState": "no_data",
-                    "notifications": []
-                  },
-                  "aliasColors": {},
-                  "bars": false,
-                  "dashLength": 10,
-                  "dashes": false,
-                  "datasource": "Prometheus",
-                  "fill": 1,
-                  "id": 42,
-                  "legend": {
-                    "avg": false,
-                    "current": false,
-                    "max": false,
-                    "min": false,
-                    "show": true,
-                    "total": false,
-                    "values": false
-                  },
-                  "lines": true,
-                  "linewidth": 1,
-                  "links": [],
-                  "nullPointMode": "null",
-                  "percentage": false,
-                  "pointradius": 5,
-                  "points": false,
-                  "renderer": "flot",
-                  "seriesOverrides": [],
-                  "spaceLength": 10,
-                  "span": 6,
-                  "stack": false,
-                  "steppedLine": false,
-                  "targets": [
-                    {
-                      "expr": "container_memory_working_set_bytes{id=\"/\",kubernetes_io_role=\"master\"} / scalar(min(machine_memory_bytes{kubernetes_io_role=\"master\"})) * 100",
-                      "format": "time_series",
-                      "hide": false,
-                      "intervalFactor": 2,
-                      "legendFormat": "{{instance}}",
-                      "refId": "A",
-                      "step": 2
-                    }
-                  ],
-                  "thresholds": [
-                    {
-                      "colorMode": "critical",
-                      "fill": true,
-                      "line": true,
-                      "op": "gt",
-                      "value": 50
-                    }
-                  ],
-                  "timeFrom": null,
-                  "timeShift": null,
-                  "title": "Master Node Memory Usage",
-                  "tooltip": {
-                    "shared": true,
-                    "sort": 0,
-                    "value_type": "individual"
-                  },
-                  "type": "graph",
-                  "xaxis": {
-                    "buckets": null,
-                    "mode": "time",
-                    "name": null,
-                    "show": true,
-                    "values": []
-                  },
-                  "yaxes": [
-                    {
-                      "format": "percent",
-                      "label": null,
-                      "logBase": 1,
-                      "max": null,
-                      "min": null,
-                      "show": true
-                    },
-                    {
-                      "format": "short",
-                      "label": null,
-                      "logBase": 1,
-                      "max": null,
-                      "min": null,
-                      "show": true
-                    }
-                  ]
-                },
-                {
-                  "alert": {
-                    "conditions": [
-                      {
-                        "evaluator": {
-                          "params": [
-                            70
-                          ],
-                          "type": "gt"
-                        },
-                        "operator": {
-                          "type": "and"
-                        },
-                        "query": {
-                          "params": [
-                            "A",
-                            "5m",
-                            "now"
-                          ]
-                        },
-                        "reducer": {
-                          "params": [],
-                          "type": "avg"
-                        },
-                        "type": "query"
-                      }
-                    ],
-                    "executionErrorState": "alerting",
-                    "frequency": "60s",
-                    "handler": 1,
-                    "name": "Node CPU Usage alert",
-                    "noDataState": "keep_state",
-                    "notifications": []
-                  },
-                  "aliasColors": {},
-                  "bars": false,
-                  "dashLength": 10,
-                  "dashes": false,
-                  "datasource": "Prometheus",
-                  "fill": 1,
-                  "id": 41,
-                  "legend": {
-                    "avg": false,
-                    "current": false,
-                    "max": false,
-                    "min": false,
-                    "show": true,
-                    "total": false,
-                    "values": false
-                  },
-                  "lines": true,
-                  "linewidth": 1,
-                  "links": [],
-                  "nullPointMode": "null",
-                  "percentage": false,
-                  "pointradius": 5,
-                  "points": false,
-                  "renderer": "flot",
-                  "seriesOverrides": [],
-                  "spaceLength": 10,
-                  "span": 6,
-                  "stack": false,
-                  "steppedLine": false,
-                  "targets": [
-                    {
-                      "expr": "(sum(rate (container_cpu_usage_seconds_total{id=\"/\", kubernetes_io_role=\"master\"}[5m])) by (instance)) / scalar(sum (machine_cpu_cores{kubernetes_io_role=\"master\"})) * 100",
-                      "format": "time_series",
-                      "hide": false,
-                      "intervalFactor": 2,
-                      "legendFormat": "{{instance}}",
-                      "refId": "A",
-                      "step": 2
-                    }
-                  ],
-                  "thresholds": [
-                    {
-                      "colorMode": "critical",
-                      "fill": true,
-                      "line": true,
-                      "op": "gt",
-                      "value": 70
-                    }
-                  ],
-                  "timeFrom": null,
-                  "timeShift": null,
-                  "title": "Master Node CPU Usage",
-                  "tooltip": {
-                    "shared": true,
-                    "sort": 0,
-                    "value_type": "individual"
-                  },
-                  "type": "graph",
-                  "xaxis": {
-                    "buckets": null,
-                    "mode": "time",
-                    "name": null,
-                    "show": true,
-                    "values": []
-                  },
-                  "yaxes": [
-                    {
-                      "format": "short",
-                      "label": null,
-                      "logBase": 1,
-                      "max": null,
-                      "min": null,
-                      "show": true
-                    },
-                    {
-                      "format": "short",
-                      "label": null,
-                      "logBase": 1,
-                      "max": null,
-                      "min": null,
-                      "show": true
-                    }
-                  ]
-                }
-              ],
-              "repeat": null,
-              "repeatIteration": null,
-              "repeatRowId": null,
-              "showTitle": false,
-              "title": "Cluster Memory Usage",
-              "titleSize": "h6"
-            },
-            {
-              "collapse": false,
-              "height": 250,
-              "panels": [
-                {
-                  "alert": {
-                    "conditions": [
-                      {
-                        "evaluator": {
-                          "params": [
-                            70
-                          ],
-                          "type": "gt"
-                        },
-                        "operator": {
-                          "type": "and"
-                        },
-                        "query": {
-                          "params": [
-                            "A",
-                            "5m",
-                            "now"
-                          ]
-                        },
-                        "reducer": {
-                          "params": [],
-                          "type": "max"
-                        },
-                        "type": "query"
-                      }
-                    ],
-                    "executionErrorState": "alerting",
-                    "frequency": "60s",
-                    "handler": 1,
-                    "name": "Worker Node Memory Usage alert",
-                    "noDataState": "no_data",
-                    "notifications": []
-                  },
-                  "aliasColors": {},
-                  "bars": false,
-                  "dashLength": 10,
-                  "dashes": false,
-                  "datasource": "Prometheus",
-                  "fill": 1,
-                  "id": 43,
-                  "legend": {
-                    "avg": false,
-                    "current": false,
-                    "max": false,
-                    "min": false,
-                    "show": true,
-                    "total": false,
-                    "values": false
-                  },
-                  "lines": true,
-                  "linewidth": 1,
-                  "links": [],
-                  "nullPointMode": "null",
-                  "percentage": false,
-                  "pointradius": 5,
-                  "points": false,
-                  "renderer": "flot",
-                  "seriesOverrides": [],
-                  "spaceLength": 10,
-                  "span": 6,
-                  "stack": false,
-                  "steppedLine": false,
-                  "targets": [
-                    {
-                      "expr": "container_memory_working_set_bytes{id=\"/\",kubernetes_io_role=\"node\"} / scalar(min(machine_memory_bytes{kubernetes_io_role=\"node\"})) * 100",
-                      "format": "time_series",
-                      "hide": false,
-                      "intervalFactor": 2,
-                      "legendFormat": "{{instance}}",
-                      "refId": "A",
-                      "step": 2
-                    }
-                  ],
-                  "thresholds": [
-                    {
-                      "colorMode": "critical",
-                      "fill": true,
-                      "line": true,
-                      "op": "gt",
-                      "value": 70
-                    }
-                  ],
-                  "timeFrom": null,
-                  "timeShift": null,
-                  "title": "Worker Node Memory Usage",
-                  "tooltip": {
-                    "shared": true,
-                    "sort": 0,
-                    "value_type": "individual"
-                  },
-                  "type": "graph",
-                  "xaxis": {
-                    "buckets": null,
-                    "mode": "time",
-                    "name": null,
-                    "show": true,
-                    "values": []
-                  },
-                  "yaxes": [
-                    {
-                      "format": "percent",
-                      "label": null,
-                      "logBase": 1,
-                      "max": null,
-                      "min": null,
-                      "show": true
-                    },
-                    {
-                      "format": "short",
-                      "label": null,
-                      "logBase": 1,
-                      "max": null,
-                      "min": null,
-                      "show": true
-                    }
-                  ]
-                },
-                {
-                  "alert": {
-                    "conditions": [
-                      {
-                        "evaluator": {
-                          "params": [
-                            40
-                          ],
-                          "type": "gt"
-                        },
-                        "operator": {
-                          "type": "and"
-                        },
-                        "query": {
-                          "params": [
-                            "A",
-                            "5m",
-                            "now"
-                          ]
-                        },
-                        "reducer": {
-                          "params": [],
-                          "type": "max"
-                        },
-                        "type": "query"
-                      }
-                    ],
-                    "executionErrorState": "alerting",
-                    "frequency": "60s",
-                    "handler": 1,
-                    "name": "Worker Node CPU Usage alert",
-                    "noDataState": "no_data",
-                    "notifications": []
-                  },
-                  "aliasColors": {},
-                  "bars": false,
-                  "dashLength": 10,
-                  "dashes": false,
-                  "datasource": "Prometheus",
-                  "fill": 1,
-                  "id": 44,
-                  "legend": {
-                    "avg": false,
-                    "current": false,
-                    "max": false,
-                    "min": false,
-                    "show": true,
-                    "total": false,
-                    "values": false
-                  },
-                  "lines": true,
-                  "linewidth": 1,
-                  "links": [],
-                  "nullPointMode": "null",
-                  "percentage": false,
-                  "pointradius": 5,
-                  "points": false,
-                  "renderer": "flot",
-                  "seriesOverrides": [],
-                  "spaceLength": 10,
-                  "span": 6,
-                  "stack": false,
-                  "steppedLine": false,
-                  "targets": [
-                    {
-                      "expr": "(sum(rate (container_cpu_usage_seconds_total{id=\"/\", kubernetes_io_role=\"node\"}[5m])) by (instance)) / scalar(sum (machine_cpu_cores{kubernetes_io_role=\"node\"})) * 100",
-                      "format": "time_series",
-                      "hide": false,
-                      "intervalFactor": 2,
-                      "legendFormat": "{{instance}}",
-                      "refId": "A",
-                      "step": 2
-                    }
-                  ],
-                  "thresholds": [
-                    {
-                      "colorMode": "critical",
-                      "fill": true,
-                      "line": true,
-                      "op": "gt",
-                      "value": 40
-                    }
-                  ],
-                  "timeFrom": null,
-                  "timeShift": null,
-                  "title": "Worker Node CPU Usage",
-                  "tooltip": {
-                    "shared": true,
-                    "sort": 0,
-                    "value_type": "individual"
-                  },
-                  "type": "graph",
-                  "xaxis": {
-                    "buckets": null,
-                    "mode": "time",
-                    "name": null,
-                    "show": true,
-                    "values": []
-                  },
-                  "yaxes": [
-                    {
-                      "format": "short",
-                      "label": null,
-                      "logBase": 1,
-                      "max": null,
-                      "min": null,
-                      "show": true
-                    },
-                    {
-                      "format": "short",
-                      "label": null,
-                      "logBase": 1,
-                      "max": null,
-                      "min": null,
-                      "show": true
-                    }
-                  ]
-                }
-              ],
-              "repeat": null,
-              "repeatIteration": null,
-              "repeatRowId": null,
-              "showTitle": false,
-              "title": "Dashboard Row",
-              "titleSize": "h6"
-            },
-            {
-              "collapse": false,
-              "height": 163,
-              "panels": [
-                {
-                  "alert": {
-                    "conditions": [
-                      {
-                        "evaluator": {
-                          "params": [
-                            20000000
-                          ],
-                          "type": "gt"
-                        },
-                        "operator": {
-                          "type": "and"
-                        },
-                        "query": {
-                          "params": [
-                            "A",
-                            "5m",
-                            "now"
-                          ]
-                        },
-                        "reducer": {
-                          "params": [],
-                          "type": "avg"
-                        },
-                        "type": "query"
-                      },
-                      {
-                        "evaluator": {
-                          "params": [
-                            -20000000
-                          ],
-                          "type": "lt"
-                        },
-                        "operator": {
-                          "type": "or"
-                        },
-                        "query": {
-                          "params": [
-                            "B",
-                            "5m",
-                            "now"
-                          ]
-                        },
-                        "reducer": {
-                          "params": [],
-                          "type": "avg"
-                        },
-                        "type": "query"
-                      }
-                    ],
-                    "executionErrorState": "alerting",
-                    "frequency": "60s",
-                    "handler": 1,
-                    "name": "Cluster Network I/O Pressure Alert",
-                    "noDataState": "no_data",
-                    "notifications": []
-                  },
-                  "aliasColors": {},
-                  "bars": false,
-                  "dashLength": 10,
-                  "dashes": false,
-                  "datasource": "Prometheus",
-                  "decimals": 2,
-                  "editable": true,
-                  "error": false,
-                  "fill": 1,
-                  "grid": {},
-                  "height": "200px",
-                  "id": 32,
-                  "legend": {
-                    "alignAsTable": false,
-                    "avg": true,
-                    "current": true,
-                    "max": false,
-                    "min": false,
-                    "rightSide": false,
-                    "show": false,
-                    "sideWidth": 200,
-                    "sort": "current",
-                    "sortDesc": true,
-                    "total": false,
-                    "values": true
-                  },
-                  "lines": true,
-                  "linewidth": 2,
-                  "links": [],
-                  "nullPointMode": "connected",
-                  "percentage": false,
-                  "pointradius": 5,
-                  "points": false,
-                  "renderer": "flot",
-                  "seriesOverrides": [],
-                  "spaceLength": 10,
-                  "span": 12,
-                  "stack": false,
-                  "steppedLine": false,
-                  "targets": [
-                    {
-                      "expr": "sum (rate (container_network_receive_bytes_total{namespace != \"kube-system\"}[5m]))",
-                      "format": "time_series",
-                      "hide": false,
-                      "interval": "10s",
-                      "intervalFactor": 1,
-                      "legendFormat": "Received",
-                      "metric": "network",
-                      "refId": "A",
-                      "step": 10
-                    },
-                    {
-                      "expr": "- sum (rate (container_network_transmit_bytes_total{namespace != \"kube-system\"}[5m]))",
-                      "format": "time_series",
-                      "hide": false,
-                      "interval": "10s",
-                      "intervalFactor": 1,
-                      "legendFormat": "Sent",
-                      "metric": "network",
-                      "refId": "B",
-                      "step": 10
-                    }
-                  ],
-                  "thresholds": [
-                    {
-                      "colorMode": "critical",
-                      "fill": true,
-                      "line": true,
-                      "op": "gt",
-                      "value": 20000000
-                    }
-                  ],
-                  "timeFrom": null,
-                  "timeShift": null,
-                  "title": "Cluster Network I/O pressure",
-                  "tooltip": {
-                    "msResolution": false,
-                    "shared": true,
-                    "sort": 0,
-                    "value_type": "cumulative"
-                  },
-                  "transparent": false,
-                  "type": "graph",
-                  "xaxis": {
-                    "buckets": null,
-                    "mode": "time",
-                    "name": null,
-                    "show": true,
-                    "values": []
-                  },
-                  "yaxes": [
-                    {
-                      "format": "Bps",
-                      "label": null,
-                      "logBase": 1,
-                      "max": null,
-                      "min": null,
-                      "show": true
-                    },
-                    {
-                      "format": "Bps",
-                      "label": null,
-                      "logBase": 1,
-                      "max": null,
-                      "min": null,
-                      "show": false
-                    }
-                  ]
-                }
-              ],
-              "repeat": null,
-              "repeatIteration": null,
-              "repeatRowId": null,
-              "showTitle": false,
-              "title": "Dashboard Row",
-              "titleSize": "h6"
-            },
-            {
-              "collapse": false,
-              "height": 250,
-              "panels": [
-                {
-                  "alert": {
-                    "conditions": [
-                      {
-                        "evaluator": {
-                          "params": [
-                            50
-                          ],
-                          "type": "gt"
-                        },
-                        "operator": {
-                          "type": "and"
-                        },
-                        "query": {
-                          "params": [
-                            "A",
-                            "5m",
-                            "now"
-                          ]
-                        },
-                        "reducer": {
-                          "params": [],
-                          "type": "avg"
-                        },
-                        "type": "query"
-                      }
-                    ],
-                    "executionErrorState": "alerting",
-                    "frequency": "60s",
-                    "handler": 1,
-                    "name": "Cluster File System Usage Alert",
-                    "noDataState": "keep_state",
-                    "notifications": []
-                  },
-                  "aliasColors": {},
-                  "bars": false,
-                  "dashLength": 10,
-                  "dashes": false,
-                  "datasource": "Prometheus",
-                  "fill": 1,
-                  "id": 35,
-                  "legend": {
-                    "alignAsTable": false,
-                    "avg": false,
-                    "current": false,
-                    "hideEmpty": true,
-                    "hideZero": true,
-                    "max": false,
-                    "min": false,
-                    "show": true,
-                    "total": false,
-                    "values": false
-                  },
-                  "lines": true,
-                  "linewidth": 1,
-                  "links": [],
-                  "nullPointMode": "connected",
-                  "percentage": false,
-                  "pointradius": 5,
-                  "points": false,
-                  "renderer": "flot",
-                  "seriesOverrides": [],
-                  "spaceLength": 10,
-                  "span": 12,
-                  "stack": false,
-                  "steppedLine": false,
-                  "targets": [
-                    {
-                      "expr": "sum (container_fs_usage_bytes{device=~\"^/dev/xvda.?$\",id=\"/\"}) by (instance) / sum (container_fs_limit_bytes{device=~\"^/dev/xvda.?$\",id=\"/\"}) by (instance)",
-                      "format": "time_series",
-                      "hide": false,
-                      "intervalFactor": 2,
-                      "legendFormat": "{{instance}}",
-                      "refId": "A",
-                      "step": 2
-                    }
-                  ],
-                  "thresholds": [
-                    {
-                      "colorMode": "critical",
-                      "fill": true,
-                      "line": true,
-                      "op": "gt",
-                      "value": 50
-                    }
-                  ],
-                  "timeFrom": null,
-                  "timeShift": null,
-                  "title": "Container-specific file system usage",
-                  "tooltip": {
-                    "shared": true,
-                    "sort": 0,
-                    "value_type": "individual"
-                  },
-                  "type": "graph",
-                  "xaxis": {
-                    "buckets": null,
-                    "mode": "time",
-                    "name": null,
-                    "show": true,
-                    "values": []
-                  },
-                  "yaxes": [
-                    {
-                      "format": "percentunit",
-                      "label": null,
-                      "logBase": 1,
-                      "max": null,
-                      "min": null,
-                      "show": true
-                    },
-                    {
-                      "format": "short",
-                      "label": null,
-                      "logBase": 1,
-                      "max": null,
-                      "min": null,
-                      "show": true
-                    }
-                  ]
-                }
-              ],
-              "repeat": null,
-              "repeatIteration": null,
-              "repeatRowId": null,
-              "showTitle": false,
-              "title": "Dashboard Row",
-              "titleSize": "h6"
-            },
-            {
-              "collapse": false,
-              "height": 250,
-              "panels": [
-                {
-                  "alert": {
-                    "conditions": [
-                      {
-                        "evaluator": {
-                          "params": [
-                            1
-                          ],
-                          "type": "gt"
-                        },
-                        "operator": {
-                          "type": "and"
-                        },
-                        "query": {
-                          "params": [
-                            "A",
-                            "5m",
-                            "now"
-                          ]
-                        },
-                        "reducer": {
-                          "params": [],
-                          "type": "avg"
-                        },
-                        "type": "query"
-                      }
-                    ],
-                    "executionErrorState": "alerting",
-                    "frequency": "60s",
-                    "handler": 1,
-                    "name": "Cluster Nodes Unavailable Alert",
-                    "noDataState": "alerting",
-                    "notifications": []
-                  },
-                  "aliasColors": {},
-                  "bars": false,
-                  "dashLength": 10,
-                  "dashes": false,
-                  "datasource": "Prometheus",
-                  "fill": 1,
-                  "id": 36,
-                  "legend": {
-                    "avg": false,
-                    "current": false,
-                    "max": false,
-                    "min": false,
-                    "show": false,
-                    "total": false,
-                    "values": false
-                  },
-                  "lines": true,
-                  "linewidth": 1,
-                  "links": [],
-                  "nullPointMode": "null",
-                  "percentage": false,
-                  "pointradius": 5,
-                  "points": false,
-                  "renderer": "flot",
-                  "seriesOverrides": [],
-                  "spaceLength": 10,
-                  "span": 12,
-                  "stack": false,
-                  "steppedLine": false,
-                  "targets": [
-                    {
-                      "expr": "sum(kube_node_status_ready{condition!=\"true\"})",
-                      "format": "time_series",
-                      "intervalFactor": 2,
-                      "metric": "kube_node_status_ready",
-                      "refId": "A",
-                      "step": 2
-                    }
-                  ],
-                  "thresholds": [
-                    {
-                      "colorMode": "critical",
-                      "fill": true,
-                      "line": true,
-                      "op": "gt",
-                      "value": 1
-                    }
-                  ],
-                  "timeFrom": null,
-                  "timeShift": null,
-                  "title": "Cluster Nodes Unavailable",
-                  "tooltip": {
-                    "shared": true,
-                    "sort": 0,
-                    "value_type": "individual"
-                  },
-                  "type": "graph",
-                  "xaxis": {
-                    "buckets": null,
-                    "mode": "time",
-                    "name": null,
-                    "show": true,
-                    "values": []
-                  },
-                  "yaxes": [
-                    {
-                      "format": "short",
-                      "label": null,
-                      "logBase": 1,
-                      "max": null,
-                      "min": "0",
-                      "show": true
-                    },
-                    {
-                      "format": "short",
-                      "label": null,
-                      "logBase": 1,
-                      "max": null,
-                      "min": null,
-                      "show": true
-                    }
-                  ]
-                }
-              ],
-              "repeat": null,
-              "repeatIteration": null,
-              "repeatRowId": null,
-              "showTitle": false,
-              "title": "Dashboard Row",
-              "titleSize": "h6"
-            },
-            {
-              "collapse": false,
-              "height": 250,
-              "panels": [
-                {
-                  "alert": {
-                    "conditions": [
-                      {
-                        "evaluator": {
-                          "params": [
-                            4
-                          ],
-                          "type": "lt"
-                        },
-                        "operator": {
-                          "type": "and"
-                        },
-                        "query": {
-                          "params": [
-                            "A",
-                            "5m",
-                            "now"
-                          ]
-                        },
-                        "reducer": {
-                          "params": [],
-                          "type": "avg"
-                        },
-                        "type": "query"
-                      }
-                    ],
-                    "executionErrorState": "alerting",
-                    "frequency": "60s",
-                    "handler": 1,
-                    "name": "Cluster Cores Available Alert",
-                    "noDataState": "no_data",
-                    "notifications": []
-                  },
-                  "aliasColors": {},
-                  "bars": false,
-                  "dashLength": 10,
-                  "dashes": false,
-                  "datasource": "Prometheus",
-                  "fill": 1,
-                  "id": 37,
-                  "legend": {
-                    "avg": false,
-                    "current": false,
-                    "max": false,
-                    "min": false,
-                    "show": false,
-                    "total": false,
-                    "values": false
-                  },
-                  "lines": true,
-                  "linewidth": 1,
-                  "links": [],
-                  "nullPointMode": "null",
-                  "percentage": false,
-                  "pointradius": 5,
-                  "points": false,
-                  "renderer": "flot",
-                  "seriesOverrides": [],
-                  "spaceLength": 10,
-                  "span": 12,
-                  "stack": false,
-                  "steppedLine": false,
-                  "targets": [
-                    {
-                      "expr": "sum(kube_node_status_allocatable_cpu_cores) - sum(kube_pod_container_resource_requests_cpu_cores)",
-                      "format": "time_series",
-                      "intervalFactor": 2,
-                      "metric": "kube_node_status_allocatable_cpu_cores",
-                      "refId": "A",
-                      "step": 2
-                    }
-                  ],
-                  "thresholds": [
-                    {
-                      "colorMode": "critical",
-                      "fill": true,
-                      "line": true,
-                      "op": "lt",
-                      "value": 4
-                    }
-                  ],
-                  "timeFrom": null,
-                  "timeShift": null,
-                  "title": "Cluster Cores Available",
-                  "tooltip": {
-                    "shared": true,
-                    "sort": 0,
-                    "value_type": "individual"
-                  },
-                  "type": "graph",
-                  "xaxis": {
-                    "buckets": null,
-                    "mode": "time",
-                    "name": null,
-                    "show": true,
-                    "values": []
-                  },
-                  "yaxes": [
-                    {
-                      "format": "short",
-                      "label": null,
-                      "logBase": 1,
-                      "max": null,
-                      "min": null,
-                      "show": true
-                    },
-                    {
-                      "format": "short",
-                      "label": null,
-                      "logBase": 1,
-                      "max": null,
-                      "min": null,
-                      "show": true
-                    }
-                  ]
-                }
-              ],
-              "repeat": null,
-              "repeatIteration": null,
-              "repeatRowId": null,
-              "showTitle": false,
-              "title": "Dashboard Row",
-              "titleSize": "h6"
-            },
-            {
-              "collapse": false,
-              "height": 250,
-              "panels": [
-                {
-                  "alert": {
-                    "conditions": [
-                      {
-                        "evaluator": {
-                          "params": [
-                            1.5
-                          ],
-                          "type": "lt"
-                        },
-                        "operator": {
-                          "type": "and"
-                        },
-                        "query": {
-                          "params": [
-                            "A",
-                            "5m",
-                            "now"
-                          ]
-                        },
-                        "reducer": {
-                          "params": [],
-                          "type": "max"
-                        },
-                        "type": "query"
-                      }
-                    ],
-                    "executionErrorState": "alerting",
-                    "frequency": "60s",
-                    "handler": 1,
-                    "name": "Most Node Cores Available Alert",
-                    "noDataState": "alerting",
-                    "notifications": []
-                  },
-                  "aliasColors": {},
-                  "bars": false,
-                  "dashLength": 10,
-                  "dashes": false,
-                  "datasource": "Prometheus",
-                  "fill": 1,
-                  "id": 38,
-                  "legend": {
-                    "avg": false,
-                    "current": false,
-                    "max": false,
-                    "min": false,
-                    "show": true,
-                    "total": false,
-                    "values": false
-                  },
-                  "lines": true,
-                  "linewidth": 1,
-                  "links": [],
-                  "nullPointMode": "null",
-                  "percentage": false,
-                  "pointradius": 5,
-                  "points": false,
-                  "renderer": "flot",
-                  "seriesOverrides": [],
-                  "spaceLength": 10,
-                  "span": 12,
-                  "stack": false,
-                  "steppedLine": false,
-                  "targets": [
-                    {
-                      "expr": "max((sum(kube_node_status_allocatable_cpu_cores) by (node)) - (sum(kube_pod_container_resource_requests_cpu_cores) by (node)))",
-                      "format": "time_series",
-                      "intervalFactor": 2,
-                      "legendFormat": "{{node}}",
-                      "metric": "kube_node_status_allocatable_cpu_cores",
-                      "refId": "A",
-                      "step": 2
-                    }
-                  ],
-                  "thresholds": [
-                    {
-                      "colorMode": "critical",
-                      "fill": true,
-                      "line": true,
-                      "op": "lt",
-                      "value": 1.5
-                    }
-                  ],
-                  "timeFrom": null,
-                  "timeShift": null,
-                  "title": "Most Node Cores Available",
-                  "tooltip": {
-                    "shared": true,
-                    "sort": 0,
-                    "value_type": "individual"
-                  },
-                  "type": "graph",
-                  "xaxis": {
-                    "buckets": null,
-                    "mode": "time",
-                    "name": null,
-                    "show": true,
-                    "values": []
-                  },
-                  "yaxes": [
-                    {
-                      "format": "short",
-                      "label": null,
-                      "logBase": 1,
-                      "max": null,
-                      "min": "0",
-                      "show": true
-                    },
-                    {
-                      "format": "short",
-                      "label": null,
-                      "logBase": 1,
-                      "max": null,
-                      "min": null,
-                      "show": true
-                    }
-                  ]
-                }
-              ],
-              "repeat": null,
-              "repeatIteration": null,
-              "repeatRowId": null,
-              "showTitle": false,
-              "title": "Dashboard Row",
-              "titleSize": "h6"
-            },
-            {
-              "collapse": false,
-              "height": 250,
-              "panels": [
-                {
-                  "alert": {
-                    "conditions": [
-                      {
-                        "evaluator": {
-                          "params": [
-                            5000000000
-                          ],
-                          "type": "lt"
-                        },
-                        "operator": {
-                          "type": "and"
-                        },
-                        "query": {
-                          "params": [
-                            "A",
-                            "5m",
-                            "now"
-                          ]
-                        },
-                        "reducer": {
-                          "params": [],
-                          "type": "avg"
-                        },
-                        "type": "query"
-                      }
-                    ],
-                    "executionErrorState": "alerting",
-                    "frequency": "60s",
-                    "handler": 1,
-                    "name": "Total Cluster Memory Available Alert",
-                    "noDataState": "alerting",
-                    "notifications": []
-                  },
-                  "aliasColors": {},
-                  "bars": false,
-                  "dashLength": 10,
-                  "dashes": false,
-                  "datasource": "Prometheus",
-                  "fill": 1,
-                  "id": 39,
-                  "legend": {
-                    "avg": false,
-                    "current": false,
-                    "max": false,
-                    "min": false,
-                    "show": false,
-                    "total": false,
-                    "values": false
-                  },
-                  "lines": true,
-                  "linewidth": 1,
-                  "links": [],
-                  "nullPointMode": "null",
-                  "percentage": false,
-                  "pointradius": 5,
-                  "points": false,
-                  "renderer": "flot",
-                  "seriesOverrides": [],
-                  "spaceLength": 10,
-                  "span": 12,
-                  "stack": false,
-                  "steppedLine": false,
-                  "targets": [
-                    {
-                      "expr": "sum(kube_node_status_allocatable_memory_bytes) - sum(kube_pod_container_resource_requests_memory_bytes)",
-                      "format": "time_series",
-                      "intervalFactor": 2,
-                      "metric": "",
-                      "refId": "A",
-                      "step": 2
-                    }
-                  ],
-                  "thresholds": [
-                    {
-                      "colorMode": "critical",
-                      "fill": true,
-                      "line": true,
-                      "op": "lt",
-                      "value": 5000000000
-                    }
-                  ],
-                  "timeFrom": null,
-                  "timeShift": null,
-                  "title": "Total Cluster Memory Available",
-                  "tooltip": {
-                    "shared": true,
-                    "sort": 0,
-                    "value_type": "individual"
-                  },
-                  "type": "graph",
-                  "xaxis": {
-                    "buckets": null,
-                    "mode": "time",
-                    "name": null,
-                    "show": true,
-                    "values": []
-                  },
-                  "yaxes": [
-                    {
-                      "format": "decbytes",
-                      "label": null,
-                      "logBase": 1,
-                      "max": null,
-                      "min": null,
-                      "show": true
-                    },
-                    {
-                      "format": "short",
-                      "label": null,
-                      "logBase": 1,
-                      "max": null,
-                      "min": null,
-                      "show": true
-                    }
-                  ]
-                }
-              ],
-              "repeat": null,
-              "repeatIteration": null,
-              "repeatRowId": null,
-              "showTitle": false,
-              "title": "Dashboard Row",
-              "titleSize": "h6"
-            },
-            {
-              "collapse": false,
-              "height": 250,
-              "panels": [
-                {
-                  "alert": {
-                    "conditions": [
-                      {
-                        "evaluator": {
-                          "params": [
-                            5000000000
-                          ],
-                          "type": "lt"
-                        },
-                        "operator": {
-                          "type": "and"
-                        },
-                        "query": {
-                          "params": [
-                            "A",
-                            "5m",
-                            "now"
-                          ]
-                        },
-                        "reducer": {
-                          "params": [],
-                          "type": "max"
-                        },
-                        "type": "query"
-                      }
-                    ],
-                    "executionErrorState": "alerting",
-                    "frequency": "60s",
-                    "handler": 1,
-                    "name": "Max Node Memory Available Alert",
-                    "noDataState": "alerting",
-                    "notifications": []
-                  },
-                  "aliasColors": {},
-                  "bars": false,
-                  "dashLength": 10,
-                  "dashes": false,
-                  "datasource": "Prometheus",
-                  "fill": 1,
-                  "id": 40,
-                  "legend": {
-                    "avg": false,
-                    "current": false,
-                    "max": false,
-                    "min": false,
-                    "show": true,
-                    "total": false,
-                    "values": false
-                  },
-                  "lines": true,
-                  "linewidth": 1,
-                  "links": [],
-                  "nullPointMode": "null",
-                  "percentage": false,
-                  "pointradius": 5,
-                  "points": false,
-                  "renderer": "flot",
-                  "seriesOverrides": [],
-                  "spaceLength": 10,
-                  "span": 12,
-                  "stack": false,
-                  "steppedLine": false,
-                  "targets": [
-                    {
-                      "expr": "max((sum(kube_node_status_allocatable_memory_bytes) by (node)) - (sum(kube_pod_container_resource_requests_memory_bytes) by (node)))",
-                      "format": "time_series",
-                      "intervalFactor": 2,
-                      "legendFormat": "{{node}}",
-                      "refId": "A",
-                      "step": 2
-                    }
-                  ],
-                  "thresholds": [
-                    {
-                      "colorMode": "critical",
-                      "fill": true,
-                      "line": true,
-                      "op": "lt",
-                      "value": 5000000000
-                    }
-                  ],
-                  "timeFrom": null,
-                  "timeShift": null,
-                  "title": "Max Node Memory Available",
-                  "tooltip": {
-                    "shared": true,
-                    "sort": 0,
-                    "value_type": "individual"
-                  },
-                  "type": "graph",
-                  "xaxis": {
-                    "buckets": null,
-                    "mode": "time",
-                    "name": null,
-                    "show": true,
-                    "values": []
-                  },
-                  "yaxes": [
-                    {
-                      "format": "decbytes",
-                      "label": null,
-                      "logBase": 1,
-                      "max": null,
-                      "min": null,
-                      "show": true
-                    },
-                    {
-                      "format": "short",
-                      "label": null,
-                      "logBase": 1,
-                      "max": null,
-                      "min": null,
-                      "show": true
-                    }
-                  ]
-                }
-              ],
-              "repeat": null,
-              "repeatIteration": null,
-              "repeatRowId": null,
-              "showTitle": false,
-              "title": "Dashboard Row",
-              "titleSize": "h6"
-            }
-          ],
-          "schemaVersion": 14,
-          "style": "dark",
-          "tags": [
-            "kubernetes"
-          ],
-          "templating": {
-            "list": []
-          },
-          "time": {
-            "from": "now-7d",
-            "to": "now"
-          },
-          "timepicker": {
-            "refresh_intervals": [
-              "5s",
-              "10s",
-              "30s",
-              "1m",
-              "5m",
-              "15m",
-              "30m",
-              "1h",
-              "2h",
-              "1d"
-            ],
-            "time_options": [
-              "5m",
-              "15m",
-              "1h",
-              "6h",
-              "12h",
-              "24h",
-              "2d",
-              "7d",
-              "30d"
-            ]
-          },
-          "timezone": "browser",
-          "title": "Kubernetes Cluster Alarms",
-          "version": 11
+    {
+      "annotations": {
+        "list": [
+        {
+          "builtIn": 1,
+          "datasource": "-- Grafana --",
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "type": "dashboard"
         }
+        ]
+      },
+      "description": "Monitors Kubernetes cluster using Prometheus. Shows overall cluster CPU / Memory / Filesystem usage as well as individual pod, containers, systemd services statistics. Uses cAdvisor metrics only.",
+      "editable": false,
+      "gnetId": 315,
+      "graphTooltip": 0,
+      "links": [],
+      "panels": [
+      {
+        "alert": {
+          "conditions": [
+          {
+            "evaluator": {
+              "params": [
+                70
+              ],
+              "type": "gt"
+            },
+            "operator": {
+              "type": "and"
+            },
+            "query": {
+              "params": [
+                "A",
+                "5m",
+                "now"
+              ]
+            },
+            "reducer": {
+              "params": [],
+              "type": "max"
+            },
+            "type": "query"
+          }
+          ],
+          "executionErrorState": "alerting",
+          "frequency": "60s",
+          "handler": 1,
+          "name": "Worker Node Memory Usage alert",
+          "noDataState": "no_data",
+          "notifications": []
+        },
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "Prometheus",
+        "fill": 1,
+        "gridPos": {
+          "h": 7,
+          "w": 12,
+          "x": 0,
+          "y": 0
+        },
+        "id": 43,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "null",
+        "paceLength": 10,
+        "percentage": false,
+        "pointradius": 5,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+        {
+          "expr": "container_memory_working_set_bytes{id=\"/\"} / scalar(min(machine_memory_bytes)) * 100",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 2,
+          "legendFormat": "{{instance}}",
+          "refId": "A",
+          "step": 2
+        }
+        ],
+        "thresholds": [
+        {
+          "colorMode": "critical",
+          "fill": true,
+          "line": true,
+          "op": "gt",
+          "value": 70
+        }
+        ],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Worker Node Memory Usage",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+        {
+          "format": "percent",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "alert": {
+          "conditions": [
+          {
+            "evaluator": {
+              "params": [
+                40
+              ],
+              "type": "gt"
+            },
+            "operator": {
+              "type": "and"
+            },
+            "query": {
+              "params": [
+                "A",
+                "5m",
+                "now"
+              ]
+            },
+            "reducer": {
+              "params": [],
+              "type": "max"
+            },
+            "type": "query"
+          }
+          ],
+          "executionErrorState": "alerting",
+          "frequency": "60s",
+          "handler": 1,
+          "name": "Worker Node CPU Usage alert",
+          "noDataState": "no_data",
+          "notifications": []
+        },
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "Prometheus",
+        "fill": 1,
+        "gridPos": {
+          "h": 7,
+          "w": 12,
+          "x": 12,
+          "y": 0
+        },
+        "id": 44,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "null",
+        "paceLength": 10,
+        "percentage": false,
+        "pointradius": 5,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+        {
+          "expr": "(sum(rate (container_cpu_usage_seconds_total{id=\"/\"}[5m])) by (instance)) / scalar(sum (machine_cpu_cores)) * 100",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 2,
+          "legendFormat": "{{instance}}",
+          "refId": "A",
+          "step": 2
+        }
+        ],
+        "thresholds": [
+        {
+          "colorMode": "critical",
+          "fill": true,
+          "line": true,
+          "op": "gt",
+          "value": 40
+        }
+        ],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Worker Node CPU Usage",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "alert": {
+          "conditions": [
+          {
+            "evaluator": {
+              "params": [
+                20000000
+              ],
+              "type": "gt"
+            },
+            "operator": {
+              "type": "and"
+            },
+            "query": {
+              "params": [
+                "A",
+                "5m",
+                "now"
+              ]
+            },
+            "reducer": {
+              "params": [],
+              "type": "avg"
+            },
+            "type": "query"
+          },
+          {
+            "evaluator": {
+              "params": [
+                -20000000
+              ],
+              "type": "lt"
+            },
+            "operator": {
+              "type": "or"
+            },
+            "query": {
+              "params": [
+                "B",
+                "5m",
+                "now"
+              ]
+            },
+            "reducer": {
+              "params": [],
+              "type": "avg"
+            },
+            "type": "query"
+          }
+          ],
+          "executionErrorState": "alerting",
+          "frequency": "60s",
+          "handler": 1,
+          "name": "Cluster Network I/O Pressure Alert",
+          "noDataState": "no_data",
+          "notifications": []
+        },
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "Prometheus",
+        "decimals": 2,
+        "editable": true,
+        "error": false,
+        "fill": 1,
+        "grid": {},
+        "gridPos": {
+          "h": 5,
+          "w": 24,
+          "x": 0,
+          "y": 7
+        },
+        "height": "200px",
+        "id": 32,
+        "legend": {
+          "alignAsTable": false,
+          "avg": true,
+          "current": true,
+          "max": false,
+          "min": false,
+          "rightSide": false,
+          "show": false,
+          "sideWidth": 200,
+          "sort": "current",
+          "sortDesc": true,
+          "total": false,
+          "values": true
+        },
+        "lines": true,
+        "linewidth": 2,
+        "links": [],
+        "nullPointMode": "connected",
+        "paceLength": 10,
+        "percentage": false,
+        "pointradius": 5,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+        {
+          "expr": "sum (rate (container_network_receive_bytes_total{namespace != \"kube-system\"}[5m]))",
+          "format": "time_series",
+          "hide": false,
+          "interval": "10s",
+          "intervalFactor": 1,
+          "legendFormat": "Received",
+          "metric": "network",
+          "refId": "A",
+          "step": 10
+        },
+        {
+          "expr": "- sum (rate (container_network_transmit_bytes_total{namespace != \"kube-system\"}[5m]))",
+          "format": "time_series",
+          "hide": false,
+          "interval": "10s",
+          "intervalFactor": 1,
+          "legendFormat": "Sent",
+          "metric": "network",
+          "refId": "B",
+          "step": 10
+        }
+        ],
+        "thresholds": [
+        {
+          "colorMode": "critical",
+          "fill": true,
+          "line": true,
+          "op": "gt",
+          "value": 20000000
+        }
+        ],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Cluster Network I/O pressure",
+        "tooltip": {
+          "msResolution": false,
+          "shared": true,
+          "sort": 0,
+          "value_type": "cumulative"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+        {
+          "format": "Bps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "Bps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "alert": {
+          "conditions": [
+          {
+            "evaluator": {
+              "params": [
+                50
+              ],
+              "type": "gt"
+            },
+            "operator": {
+              "type": "and"
+            },
+            "query": {
+              "params": [
+                "A",
+                "5m",
+                "now"
+              ]
+            },
+            "reducer": {
+              "params": [],
+              "type": "avg"
+            },
+            "type": "query"
+          }
+          ],
+          "executionErrorState": "alerting",
+          "frequency": "60s",
+          "handler": 1,
+          "name": "Cluster File System Usage Alert",
+          "noDataState": "keep_state",
+          "notifications": []
+        },
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "Prometheus",
+        "fill": 1,
+        "gridPos": {
+          "h": 7,
+          "w": 24,
+          "x": 0,
+          "y": 12
+        },
+        "id": 35,
+        "legend": {
+          "alignAsTable": false,
+          "avg": false,
+          "current": false,
+          "hideEmpty": true,
+          "hideZero": true,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "connected",
+        "paceLength": 10,
+        "percentage": false,
+        "pointradius": 5,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+        {
+          "expr": "sum (container_fs_usage_bytes{device=~\"^/dev/.{1,2}da.?$\",id=\"/\"}) by (instance) / sum (container_fs_limit_bytes{device=~\"^/dev/.{1,2}da.?$\",id=\"/\"}) by (instance)",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 2,
+          "legendFormat": "{{instance}}",
+          "refId": "A",
+          "step": 2
+        }
+        ],
+        "thresholds": [
+        {
+          "colorMode": "critical",
+          "fill": true,
+          "line": true,
+          "op": "gt",
+          "value": 50
+        }
+        ],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Container-specific file system usage",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+        {
+          "format": "percentunit",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "alert": {
+          "conditions": [
+          {
+            "evaluator": {
+              "params": [
+                1
+              ],
+              "type": "gt"
+            },
+            "operator": {
+              "type": "and"
+            },
+            "query": {
+              "params": [
+                "A",
+                "5m",
+                "now"
+              ]
+            },
+            "reducer": {
+              "params": [],
+              "type": "avg"
+            },
+            "type": "query"
+          }
+          ],
+          "executionErrorState": "alerting",
+          "frequency": "60s",
+          "handler": 1,
+          "name": "Cluster Nodes Unavailable Alert",
+          "noDataState": "alerting",
+          "notifications": []
+        },
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "Prometheus",
+        "fill": 1,
+        "gridPos": {
+          "h": 7,
+          "w": 24,
+          "x": 0,
+          "y": 19
+        },
+        "id": 36,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "null",
+        "paceLength": 10,
+        "percentage": false,
+        "pointradius": 5,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+        {
+          "expr": "sum(kube_node_status_ready{condition!=\"true\"})",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "metric": "kube_node_status_ready",
+          "refId": "A",
+          "step": 2
+        }
+        ],
+        "thresholds": [
+        {
+          "colorMode": "critical",
+          "fill": true,
+          "line": true,
+          "op": "gt",
+          "value": 1
+        }
+        ],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Cluster Nodes Unavailable",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "alert": {
+          "conditions": [
+          {
+            "evaluator": {
+              "params": [
+                4
+              ],
+              "type": "lt"
+            },
+            "operator": {
+              "type": "and"
+            },
+            "query": {
+              "params": [
+                "A",
+                "5m",
+                "now"
+              ]
+            },
+            "reducer": {
+              "params": [],
+              "type": "avg"
+            },
+            "type": "query"
+          }
+          ],
+          "executionErrorState": "alerting",
+          "frequency": "60s",
+          "handler": 1,
+          "name": "Cluster Cores Available Alert",
+          "noDataState": "no_data",
+          "notifications": []
+        },
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "Prometheus",
+        "fill": 1,
+        "gridPos": {
+          "h": 7,
+          "w": 24,
+          "x": 0,
+          "y": 26
+        },
+        "id": 37,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "null",
+        "paceLength": 10,
+        "percentage": false,
+        "pointradius": 5,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+        {
+          "expr": "sum(kube_node_status_allocatable_cpu_cores) - sum(kube_pod_container_resource_requests_cpu_cores)",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "metric": "kube_node_status_allocatable_cpu_cores",
+          "refId": "A",
+          "step": 2
+        }
+        ],
+        "thresholds": [
+        {
+          "colorMode": "critical",
+          "fill": true,
+          "line": true,
+          "op": "lt",
+          "value": 4
+        }
+        ],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Cluster Cores Available",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "alert": {
+          "conditions": [
+          {
+            "evaluator": {
+              "params": [
+                1.5
+              ],
+              "type": "lt"
+            },
+            "operator": {
+              "type": "and"
+            },
+            "query": {
+              "params": [
+                "A",
+                "5m",
+                "now"
+              ]
+            },
+            "reducer": {
+              "params": [],
+              "type": "max"
+            },
+            "type": "query"
+          }
+          ],
+          "executionErrorState": "alerting",
+          "frequency": "60s",
+          "handler": 1,
+          "name": "Most Node Cores Available Alert",
+          "noDataState": "alerting",
+          "notifications": []
+        },
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "Prometheus",
+        "fill": 1,
+        "gridPos": {
+          "h": 7,
+          "w": 24,
+          "x": 0,
+          "y": 33
+        },
+        "id": 38,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "null",
+        "paceLength": 10,
+        "percentage": false,
+        "pointradius": 5,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+        {
+          "expr": "max((sum(kube_node_status_allocatable_cpu_cores) by (node)) - (sum(kube_pod_container_resource_requests_cpu_cores) by (node)))",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{node}}",
+          "metric": "kube_node_status_allocatable_cpu_cores",
+          "refId": "A",
+          "step": 2
+        }
+        ],
+        "thresholds": [
+        {
+          "colorMode": "critical",
+          "fill": true,
+          "line": true,
+          "op": "lt",
+          "value": 1.5
+        }
+        ],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Most Node Cores Available",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "alert": {
+          "conditions": [
+          {
+            "evaluator": {
+              "params": [
+                5000000000
+              ],
+              "type": "lt"
+            },
+            "operator": {
+              "type": "and"
+            },
+            "query": {
+              "params": [
+                "A",
+                "5m",
+                "now"
+              ]
+            },
+            "reducer": {
+              "params": [],
+              "type": "avg"
+            },
+            "type": "query"
+          }
+          ],
+          "executionErrorState": "alerting",
+          "frequency": "60s",
+          "handler": 1,
+          "name": "Total Cluster Memory Available Alert",
+          "noDataState": "alerting",
+          "notifications": []
+        },
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "Prometheus",
+        "fill": 1,
+        "gridPos": {
+          "h": 7,
+          "w": 24,
+          "x": 0,
+          "y": 40
+        },
+        "id": 39,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "null",
+        "paceLength": 10,
+        "percentage": false,
+        "pointradius": 5,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+        {
+          "expr": "sum(kube_node_status_allocatable_memory_bytes) - sum(kube_pod_container_resource_requests_memory_bytes)",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "metric": "",
+          "refId": "A",
+          "step": 2
+        }
+        ],
+        "thresholds": [
+        {
+          "colorMode": "critical",
+          "fill": true,
+          "line": true,
+          "op": "lt",
+          "value": 5000000000
+        }
+        ],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Total Cluster Memory Available",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+        {
+          "format": "decbytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "alert": {
+          "conditions": [
+          {
+            "evaluator": {
+              "params": [
+                5000000000
+              ],
+              "type": "lt"
+            },
+            "operator": {
+              "type": "and"
+            },
+            "query": {
+              "params": [
+                "A",
+                "5m",
+                "now"
+              ]
+            },
+            "reducer": {
+              "params": [],
+              "type": "max"
+            },
+            "type": "query"
+          }
+          ],
+          "executionErrorState": "alerting",
+          "frequency": "60s",
+          "handler": 1,
+          "name": "Max Node Memory Available Alert",
+          "noDataState": "alerting",
+          "notifications": []
+        },
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "Prometheus",
+        "fill": 1,
+        "gridPos": {
+          "h": 7,
+          "w": 24,
+          "x": 0,
+          "y": 47
+        },
+        "id": 40,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "null",
+        "paceLength": 10,
+        "percentage": false,
+        "pointradius": 5,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+        {
+          "expr": "max((sum(kube_node_status_allocatable_memory_bytes) by (node)) - (sum(kube_pod_container_resource_requests_memory_bytes) by (node)))",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{node}}",
+          "refId": "A",
+          "step": 2
+        }
+        ],
+        "thresholds": [
+        {
+          "colorMode": "critical",
+          "fill": true,
+          "line": true,
+          "op": "lt",
+          "value": 5000000000
+        }
+        ],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Max Node Memory Available",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+        {
+          "format": "decbytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      }
+      ],
+      "refresh": false,
+      "schemaVersion": 18,
+      "style": "dark",
+      "tags": [
+        "kubernetes"
+      ],
+      "templating": {
+        "list": []
+      },
+      "time": {
+        "from": "now-7d",
+        "to": "now"
+      },
+      "timepicker": {
+        "refresh_intervals": [
+          "5s",
+          "10s",
+          "30s",
+          "1m",
+          "5m",
+          "15m",
+          "30m",
+          "1h",
+          "2h",
+          "1d"
+        ],
+        "time_options": [
+          "5m",
+          "15m",
+          "1h",
+          "6h",
+          "12h",
+          "24h",
+          "2d",
+          "7d",
+          "30d"
+        ]
+      },
+      "timezone": "browser",
+      "title": "Kubernetes Cluster Alarms",
+      "uid": "__HREFjmk",
+      "version": 2
+    }


### PR DESCRIPTION
1. Removed master node graphs that relies on kubernetes_io_role not available in gke.
>This is obviously environment-dependent, so it should probably go into a `go-dev-gke` branch that stays in sync with `go-dev`.

2. Changed fs usage device regex to cater for /dev/sda and /dev/xvda.
>This should be ok for all envs.